### PR TITLE
Minor documentation fix

### DIFF
--- a/src/device_impl.rs
+++ b/src/device_impl.rs
@@ -64,7 +64,7 @@ where
         self.write_register(Register::PDRIVER, pdriver | BitFlags::OSC)
     }
 
-    /// Enable the oscillator.
+    /// Disable the oscillator.
     pub fn disable_oscillator(&mut self) -> Result<(), Error<E>> {
         let pdriver = self.read_register(Register::PDRIVER)?;
         self.write_register(Register::PDRIVER, pdriver & !BitFlags::OSC)


### PR DESCRIPTION
A minor typo in the documentation that was bothering me.

Changed  documentation for `disable_oscillator` function